### PR TITLE
Update transifex branch deletions.

### DIFF
--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -357,7 +357,11 @@ class Repo:
             logger.info('Deleting branch %s:%s.', self.name, self.branch_name)
             # Delete branch from remote. See https://developer.github.com/v3/git/refs/#get-a-reference.
             ref = 'heads/{branch}'.format(branch=self.branch_name)
-            self.github_repo.get_git_ref(ref).delete()
+            # This line is in a try/except because some repos auto-delete branches.
+            try:
+                self.github_repo.get_git_ref(ref).delete()
+            except github.GithubException.UnknownObjectException:
+                logger.info('Branch not found %s:%s.', self.name, self.branch_name)
 
         # Delete cloned repo.
         subprocess.run(['rm', '-rf', self.name], check=True)


### PR DESCRIPTION
A memoir by `transifex/utils.py`:
What's happening to me here?
I'm being made much more robust and can now be used for repos that do or don't auto-delete branches!

How did I end up here?
Why that's quite simple, automated transifex pulls were first introduced by the ecommerce team! 

Should I be moved?
Possibly?

Will the new me fix https://openedx.atlassian.net/projects/CR/queues/issue/CR-1225?
Maybe?  There are several ways transifex fails, but this will fix one of them.

Why does edX auto-delete branches?
I consulted with DevOps and they told me that auto-deleting branches helps keep things clean and that branches can easily be restored if needed.

